### PR TITLE
add escaping of delimiters

### DIFF
--- a/example/date_format_example.dart
+++ b/example/date_format_example.dart
@@ -41,4 +41,6 @@ main() {
 
   print(formatDate(
       DateTime(1989, 02, 1, 15, 40, 10), [HH, ':', nn, ':', ss, ' ', Z]));
+      
+  print(formatDate(DateTime(2020, 04, 18, 21, 14), [H, '\\h', n]));
 }

--- a/lib/src/date_format_base.dart
+++ b/lib/src/date_format_base.dart
@@ -223,12 +223,23 @@ const String am = 'am';
 const String z = 'z';
 const String Z = 'Z';
 
+/// Escape
+///
+/// Example:
+///     formatDate(DateTime(1989, 02, 1, 15, 40), [HH,'\h',nn]);
+///     // => 15h40
+///
+
+const String escape = '\\';
+
 String formatDate(DateTime date, List<String> formats,
     {Locale locale = const EnglishLocale()}) {
   final sb = StringBuffer();
 
   for (String format in formats) {
-    if (format == yyyy) {
+    if (format.startsWith(escape)) {
+      sb.write(format.replaceAll(escape, ''));
+    } else if (format == yyyy) {
       sb.write(_digits(date.year, 4));
     } else if (format == yy) {
       sb.write(_digits(date.year % 100, 2));

--- a/lib/src/date_format_base.dart
+++ b/lib/src/date_format_base.dart
@@ -223,10 +223,10 @@ const String am = 'am';
 const String z = 'z';
 const String Z = 'Z';
 
-/// Escape
+/// Escape delimiters to be used as normal string.
 ///
 /// Example:
-///     formatDate(DateTime(1989, 02, 1, 15, 40), [HH,'\h',nn]);
+///     formatDate(DateTime(1989, 02, 1, 15, 40), [HH,'\\h',nn]);
 ///     // => 15h40
 ///
 

--- a/lib/src/locale/portuguese.dart
+++ b/lib/src/locale/portuguese.dart
@@ -52,4 +52,10 @@ class PortugueseLocale implements Locale {
     'Sábado',
     'Domingo'
   ];
+
+  @override
+  String get am => "AM";
+
+  @override
+  String get pm => "PM";
 }

--- a/lib/src/locale/spanish.dart
+++ b/lib/src/locale/spanish.dart
@@ -52,4 +52,10 @@ class SpanishLocale implements Locale {
     'Sábado',
     'Domingo'
   ];
+
+  @override
+  String get am => "AM";
+
+  @override
+  String get pm => "PM";
 }

--- a/test/date_format_test.dart
+++ b/test/date_format_test.dart
@@ -81,5 +81,9 @@ void main() {
       expect(formatDate(DateTime(2018, 1, 25), [yy, '-', M, '-', D], locale: SpanishLocale()),
           '18-Ene-Jue');
     });
+
+    test("Escaping", () {
+      expect(formatDate(DateTime(2020, 04, 18, 21, 14), [H, '\\h', n]), '21h14');
+    });
   });
 }


### PR DESCRIPTION
Typical usage of escaping is to be able to print something like: 21h54.

if we don't have any way to escape the 'h' from the format, we'll end up with it being interpreted as a normal compact hour.
