### PR TITLE
Fix millisecond/second Bug when typing S

### DIFF
--- a/lib/src/date_format_base.dart
+++ b/lib/src/date_format_base.dart
@@ -291,7 +291,7 @@ String formatDate(DateTime date, List<String> formats,
     } else if (format == SSS) {
       sb.write(_digits(date.millisecond, 3));
     } else if (format == S) {
-      sb.write(date.second);
+      sb.write(date.millisecond);
     } else if (format == uuu) {
       sb.write(_digits(date.microsecond, 2));
     } else if (format == u) {


### PR DESCRIPTION
When typing S to show Milliseconds it shows seconds