### PR TITLE
Fix the microsecond padding

### DIFF
--- a/lib/src/date_format_base.dart
+++ b/lib/src/date_format_base.dart
@@ -293,7 +293,7 @@ String formatDate(DateTime date, List<String> formats,
     } else if (format == S) {
       sb.write(date.millisecond);
     } else if (format == uuu) {
-      sb.write(_digits(date.microsecond, 2));
+      sb.write(_digits(date.microsecond, 3));
     } else if (format == u) {
       sb.write(date.microsecond);
     } else if (format == z) {


### PR DESCRIPTION
Microseconds are 0..999 so they need to be properly zero-padded.